### PR TITLE
Fixed LoadError problem when running deck

### DIFF
--- a/bin/deck
+++ b/bin/deck
@@ -38,8 +38,6 @@ if options[:build]
 
 else
 
-  # Fix Rack bug https://github.com/rack/rack/issues/301
-  require 'deck/rack_static_patch'
   port = options[:port]
   slide_files = ARGV
   Rack::Handler.default.run Deck::RackApp.build(slide_files), :Port => port


### PR DESCRIPTION
deck/rack_static_patch is removed from f1e6e3803 but the executable was not updated. Fixes #5
