### PR TITLE
Fix for duplicate key in Redcarpet::Markdown initialization

### DIFF
--- a/lib/deck/slide.rb
+++ b/lib/deck/slide.rb
@@ -86,7 +86,6 @@ module Deck
       :no_intra_emphasis => true,
       :tables => true,
       :fenced_code_blocks => true,
-      :no_intra_emphasis => true,
       :autolink => true,
       :strikethrough => true,
       :lax_html_blocks => false,


### PR DESCRIPTION
Warnings are emitted in execution and testing when Deck.rb code is used due to
the duplicate keys within the Redcarpet::Markdown.new initialization.