### PR TITLE
Allow 'should' and 'expect' usage in expectations and mocks

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,12 @@ require "files"
 
 require "deck/noko"
 include Deck::Noko
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION
Mocking with `should_receive` has been deprecated. This change disables the warnings emitted during testing and allows both the `expect` and `should` syntax explicitly.

More information:
https://relishapp.com/rspec/rspec-mocks/docs/old-syntax/should-receive