### PR TITLE
Fix NameError due to missing 'require "date"' within 'spec_helper'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ here = File.expand_path File.dirname(__FILE__)
 top = File.expand_path "#{here}/.."
 $: << "#{top}/lib"
 
+require "date"
 require "rspec"
 require "wrong/adapters/rspec"
 require "nokogiri"


### PR DESCRIPTION
When running tests with the default Rake task 'rake' will emit errors related to
NameError due to a missing 'require "date"'. The origin of the error is due to
'Failure/Error: require "wrong/adapters/rspec"'.