### PR TITLE
Redcarpet has a XSS vulnerability in versions < 3.2.2

### DIFF
--- a/deck.gemspec
+++ b/deck.gemspec
@@ -20,7 +20,7 @@ deck.js (http://imakewebthings.github.com/deck.js) is a JavaScript library for b
   s.extra_rdoc_files = %w[README.md]
 
   s.add_dependency "erector", ">= 0.9.0"
-  s.add_dependency "redcarpet", "~> 2"
+  s.add_dependency "redcarpet", "~> 3.4"
   s.add_dependency "rack", ">= 1.4.1"
   s.add_dependency "thin"  # forget webrick
   s.add_dependency "trollop"


### PR DESCRIPTION
See the details of the report for the vulnerability OSVDB-120415:
http://danlec.com/blog/bug-in-sundown-and-redcarpet

This update is a drop in replacement and all tests within Deck.rb pass.