### PR TITLE
Update the 'trollop' gem to instead use the new name 'optimist'

### DIFF
--- a/bin/deck
+++ b/bin/deck
@@ -3,15 +3,14 @@
 here = File.expand_path(File.dirname(__FILE__))
 $: << File.join(here, '..', 'lib')
 
-require "trollop"
+require "optimist"
 require "rack"
 require "deck"
 require "deck/rack_app"
 require "deck/version"
 require "thin" # i hate webrick
 
-# todo: use the newer version of Trollop with the less offensive name
-options = Trollop.options do
+options = Optimist.options do
   version "deck v#{Deck::VERSION}"
   banner version
   banner "Usage: deck [options] [slides]"

--- a/deck.gemspec
+++ b/deck.gemspec
@@ -23,7 +23,7 @@ deck.js (http://imakewebthings.github.com/deck.js) is a JavaScript library for b
   s.add_dependency "redcarpet", "~> 2"
   s.add_dependency "rack", ">= 1.4.1"
   s.add_dependency "thin"  # forget webrick
-  s.add_dependency "trollop"
+  s.add_dependency "optimist", "~> 3.0"
   s.add_dependency "nokogiri"
   s.add_dependency "json"
 end


### PR DESCRIPTION
This is a drop in replacement after renaming the class requires and calls.

Fixes deprecation notice. All tests pass.